### PR TITLE
Gatk4 fix input name

### DIFF
--- a/multi-samples/Tools/gatk4-IndelsVariantRecalibrator-biggest-practices.cwl
+++ b/multi-samples/Tools/gatk4-IndelsVariantRecalibrator-biggest-practices.cwl
@@ -21,7 +21,7 @@ inputs:
       position: 1
       prefix: --java-options
       shellQuote: true
-  gvcf:
+  sites_only_variant_filtered_vcf:
     type: File
     inputBinding:
       position: 3


### PR DESCRIPTION
.sites_only.vcf.gzがinputなのに、input名をgvcfとしていた。
input名をsites_only_variant_filtered_vcfに変更